### PR TITLE
refactor: #129 member, pointPolicy 삭제는 상태변경으로 관리

### DIFF
--- a/src/main/java/com/nhnacademy/illuwa/domain/member/service/MemberService.java
+++ b/src/main/java/com/nhnacademy/illuwa/domain/member/service/MemberService.java
@@ -28,6 +28,4 @@ public interface MemberService {
     void reactivateMember(long memberId);
 
     void removeMember(long memberId);
-
-    boolean isNotActiveMember(long memberId);
 }

--- a/src/main/java/com/nhnacademy/illuwa/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/nhnacademy/illuwa/domain/member/service/impl/MemberServiceImpl.java
@@ -184,14 +184,10 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public void removeMember(long memberId) {
-        if(!memberRepository.existsById(memberId)){
-            throw new MemberNotFoundException(memberId);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(memberId));
+        if(!memberRepository.isNotActiveMember(memberId)){
+            member.changeStatus(Status.DELETED);
         }
-        memberRepository.deleteById(memberId);
-    }
-
-    @Override
-    public boolean isNotActiveMember(long memberId) {
-        return memberRepository.isNotActiveMember(memberId);
     }
 }

--- a/src/main/java/com/nhnacademy/illuwa/domain/pointpolicy/dto/PointPolicyCreateRequest.java
+++ b/src/main/java/com/nhnacademy/illuwa/domain/pointpolicy/dto/PointPolicyCreateRequest.java
@@ -3,16 +3,12 @@ package com.nhnacademy.illuwa.domain.pointpolicy.dto;
 import com.nhnacademy.illuwa.domain.pointpolicy.entity.enums.PointValueType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 
 @Data
-@NoArgsConstructor
-@AllArgsConstructor
 @Builder
 public class PointPolicyCreateRequest {
     @NotBlank(message = "포인트 정책 키 설정은 필수입니다.")

--- a/src/main/java/com/nhnacademy/illuwa/domain/pointpolicy/dto/PointPolicyUpdateRequest.java
+++ b/src/main/java/com/nhnacademy/illuwa/domain/pointpolicy/dto/PointPolicyUpdateRequest.java
@@ -7,8 +7,6 @@ import lombok.*;
 import java.math.BigDecimal;
 
 @Data
-@NoArgsConstructor
-@AllArgsConstructor
 @Builder
 public class PointPolicyUpdateRequest {
     @NotNull(message = "포인트 값은 필수입니다.")

--- a/src/main/java/com/nhnacademy/illuwa/domain/pointpolicy/entity/PointPolicy.java
+++ b/src/main/java/com/nhnacademy/illuwa/domain/pointpolicy/entity/PointPolicy.java
@@ -1,6 +1,7 @@
 package com.nhnacademy.illuwa.domain.pointpolicy.entity;
 
 import com.nhnacademy.illuwa.domain.pointpolicy.entity.enums.PointValueType;
+import com.nhnacademy.illuwa.domain.pointpolicy.entity.enums.PolicyStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -33,6 +34,10 @@ public class PointPolicy {
     @Column(name = "description", nullable = false)
     private String description;
 
+    @Builder.Default
+    @Column(name = "status", nullable = false)
+    private PolicyStatus status = PolicyStatus.ACTIVE;
+
     public void changeValue(BigDecimal value) {
         this.value = value;
     }
@@ -44,5 +49,10 @@ public class PointPolicy {
     public void changeDescription(String description) {
         this.description = description;
     }
+
+    public void changeStatus(PolicyStatus status) {
+        this.status = status;
+    }
+
 }
 

--- a/src/main/java/com/nhnacademy/illuwa/domain/pointpolicy/entity/enums/PolicyStatus.java
+++ b/src/main/java/com/nhnacademy/illuwa/domain/pointpolicy/entity/enums/PolicyStatus.java
@@ -1,0 +1,5 @@
+package com.nhnacademy.illuwa.domain.pointpolicy.entity.enums;
+
+public enum PolicyStatus {
+    ACTIVE, INACTIVE
+}

--- a/src/test/java/com/nhnacademy/illuwa/domain/member/service/impl/MemberServiceImplTest.java
+++ b/src/test/java/com/nhnacademy/illuwa/domain/member/service/impl/MemberServiceImplTest.java
@@ -30,6 +30,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -191,15 +192,15 @@ class MemberServiceImplTest {
     @Test
     @DisplayName("회원 삭제 성공")
     void removeMember_success() {
-        when(memberRepository.existsById(anyLong())).thenReturn(true);
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(testMember));
         memberService.removeMember(1L);
-        verify(memberRepository).deleteById(1L);
+        assertEquals(Status.DELETED, testMember.getStatus());
     }
 
     @Test
     @DisplayName("회원 삭제 실패 - 존재하지 않음")
     void removeMember_notExists_throwsException() {
-        when(memberRepository.existsById(anyLong())).thenReturn(false);
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.empty());
         assertThrows(MemberNotFoundException.class, () -> memberService.removeMember(999L));
     }
 }

--- a/src/test/java/com/nhnacademy/illuwa/domain/pointpolicy/service/impl/PointPolicyServiceImplTest.java
+++ b/src/test/java/com/nhnacademy/illuwa/domain/pointpolicy/service/impl/PointPolicyServiceImplTest.java
@@ -6,6 +6,7 @@ import com.nhnacademy.illuwa.domain.pointpolicy.dto.PointPolicyResponse;
 import com.nhnacademy.illuwa.domain.pointpolicy.dto.PointPolicyUpdateRequest;
 import com.nhnacademy.illuwa.domain.pointpolicy.entity.PointPolicy;
 import com.nhnacademy.illuwa.domain.pointpolicy.entity.enums.PointValueType;
+import com.nhnacademy.illuwa.domain.pointpolicy.entity.enums.PolicyStatus;
 import com.nhnacademy.illuwa.domain.pointpolicy.exception.DuplicatePointPolicyException;
 import com.nhnacademy.illuwa.domain.pointpolicy.exception.PointPolicyNotFoundException;
 import com.nhnacademy.illuwa.domain.pointpolicy.repo.PointPolicyRepository;
@@ -78,7 +79,13 @@ class PointPolicyServiceImplTest {
     @Test
     @DisplayName("포인트 정책 등록 - 중복된 policyKey 예외 발생")
     void testCreatePointPolicy_DuplicateKey() {
-        PointPolicyCreateRequest request = new PointPolicyCreateRequest("duplicate", new BigDecimal("1000"), PointValueType.AMOUNT, "설명1");
+        PointPolicyCreateRequest request = PointPolicyCreateRequest
+                .builder()
+                .policyKey("duplicate")
+                .value(new BigDecimal("1000"))
+                .valueType(PointValueType.AMOUNT)
+                .description("설명1")
+                .build();
 
         PointPolicy existingPolicy = PointPolicy.builder()
                 .policyKey("duplicate")
@@ -189,10 +196,8 @@ class PointPolicyServiceImplTest {
     @DisplayName("포인트 정책 삭제 - 성공")
     void testDeletePointPolicy() {
         when(pointPolicyRepository.findById("thanks_point")).thenReturn(Optional.of(testPolicy));
-
         pointPolicyService.deletePointPolicy("thanks_point");
-
-        verify(pointPolicyRepository).deleteById("thanks_point");
+        assertEquals(PolicyStatus.INACTIVE, testPolicy.getStatus());
     }
 
     @Test


### PR DESCRIPTION
## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명
- member 탈퇴
- PointPolicy 삭제
- 는 비활성화(status 필드)로 수정

## 💬리뷰 요구사항(선택)

## Issue Tags
> 아래 # 태그 뒤에 이슈 번호 붙여주세요!
- Closed: #129
