### PR TITLE
feat: #167 포인트정책 관리 front와 연결

### DIFF
--- a/http/PointPolicy.http
+++ b/http/PointPolicy.http
@@ -1,46 +1,14 @@
-### (임시) 관리자 포인트정책 등록(관리자 계정과 함께 초기데이터 넣어줘야함)
-POST http://localhost:8080/members/admin/point-policies
-Content-Type: application/json
-
-[
-  {
-    "policyKey": "join_point",
-    "value": 5000,
-    "valueType": "amount",
-    "description": "회원가입 포인트 적립액"
-  },
-  {
-    "policyKey": "review_point",
-    "value": 200,
-    "valueType": "amount",
-    "description": "리뷰 포인트 적립액"
-  },
-  {
-    "policyKey": "photo_review_point",
-    "value": 500,
-    "valueType": "amount",
-    "description": "포토리뷰 포인트 적립액"
-  },
-  {
-    "policyKey": "book_default_rate",
-    "value": 0.01,
-    "valueType": "rate",
-    "description": "도서구매 기본 적립률"
-  }
-]
-
-
 ### 관리자 포인트정책 조회
-GET http://localhost:8080/members/admin/point-policies
+GET http://localhost:10303/admin/point-policies
 Content-Type: application/json
 
 ### 관리자 포인트정책 단일조회
-GET http://localhost:8080/members/admin/point-policies/book_default_rate
+GET http://localhost:10303/admin/point-policies/book_default_rate
 Content-Type: application/json
 
 
 ### 관리자 포인트정책 수정
-PATCH http://localhost:8080/members/admin/point-policies/join_point
+PATCH http://localhost:10303/admin/point-policies/join_point
 Content-Type: application/json
 
 {

--- a/src/main/java/com/nhnacademy/illuwa/common/advice/PointPolicyGlobalExceptionHandler.java
+++ b/src/main/java/com/nhnacademy/illuwa/common/advice/PointPolicyGlobalExceptionHandler.java
@@ -2,15 +2,30 @@ package com.nhnacademy.illuwa.common.advice;
 
 import com.nhnacademy.illuwa.common.exception.dto.ErrorResponse;
 import com.nhnacademy.illuwa.domain.pointpolicy.exception.DuplicatePointPolicyException;
+import com.nhnacademy.illuwa.domain.pointpolicy.exception.InactivePointPolicyException;
 import com.nhnacademy.illuwa.domain.pointpolicy.exception.PointPolicyNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
+@Order(2)
 public class PointPolicyGlobalExceptionHandler {
+
+    @ExceptionHandler(PointPolicyNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handlePolicyNotFoundException(PointPolicyNotFoundException ex, HttpServletRequest request) {
+        ErrorResponse response = ErrorResponse.of(
+                HttpStatus.NOT_FOUND.value(),
+                HttpStatus.NOT_FOUND.getReasonPhrase(),
+                "POLICY_NOT_FOUND",
+                ex.getMessage(),
+                request.getRequestURI()
+        );
+        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+    }
 
     @ExceptionHandler(DuplicatePointPolicyException.class)
     public ResponseEntity<ErrorResponse> handleDuplicatePolicy(DuplicatePointPolicyException ex, HttpServletRequest request) {
@@ -24,15 +39,15 @@ public class PointPolicyGlobalExceptionHandler {
         return new ResponseEntity<>(response, HttpStatus.CONFLICT);
     }
 
-    @ExceptionHandler(PointPolicyNotFoundException.class)
-    public ResponseEntity<ErrorResponse> handlePolicyNotFoundException(PointPolicyNotFoundException ex, HttpServletRequest request) {
+    @ExceptionHandler(InactivePointPolicyException.class)
+    public ResponseEntity<ErrorResponse> handleInactivePolicyException(InactivePointPolicyException ex, HttpServletRequest request) {
         ErrorResponse response = ErrorResponse.of(
-                HttpStatus.NOT_FOUND.value(),
-                HttpStatus.NOT_FOUND.getReasonPhrase(),
-                "POLICY_NOT_FOUND",
+                HttpStatus.BAD_REQUEST.value(),
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                "INACTIVE_POLICY",
                 ex.getMessage(),
                 request.getRequestURI()
         );
-        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/com/nhnacademy/illuwa/common/config/init/PointPolicyInitializer.java
+++ b/src/main/java/com/nhnacademy/illuwa/common/config/init/PointPolicyInitializer.java
@@ -8,6 +8,7 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -19,11 +20,10 @@ public class PointPolicyInitializer implements ApplicationRunner {
 
     private final PointPolicyRepository pointPolicyRepository;
 
+    @Transactional
     @Override
-    public void run(ApplicationArguments args){
-        if(pointPolicyRepository.count() > 0) return;
-
-        List<PointPolicy> policies = List.of(
+    public void run(ApplicationArguments args) {
+        List<PointPolicy> initPolicies = List.of(
                 PointPolicy.builder()
                         .policyKey("join_point")
                         .value(new BigDecimal("5000"))
@@ -32,26 +32,47 @@ public class PointPolicyInitializer implements ApplicationRunner {
                         .build(),
 
                 PointPolicy.builder()
-                    .policyKey("review_point")
-                    .value(new BigDecimal("200"))
-                    .valueType(PointValueType.AMOUNT)
-                    .description("리뷰 포인트 적립액")
-                    .build(),
+                        .policyKey("review_point")
+                        .value(new BigDecimal("200"))
+                        .valueType(PointValueType.AMOUNT)
+                        .description("리뷰 포인트 적립액")
+                        .build(),
 
                 PointPolicy.builder()
-                    .policyKey("photo_review_point")
-                    .value(new BigDecimal("500"))
-                    .valueType(PointValueType.AMOUNT)
-                    .description("포토리뷰 포인트 적립액")
-                    .build(),
+                        .policyKey("photo_review_point")
+                        .value(new BigDecimal("500"))
+                        .valueType(PointValueType.AMOUNT)
+                        .description("포토리뷰 포인트 적립액")
+                        .build(),
 
                 PointPolicy.builder()
-                    .policyKey("book_default_rate")
-                    .value(new BigDecimal("1.00"))
-                    .valueType(PointValueType.RATE)
-                    .description("도서구매 기본 적립률")
-                    .build()
+                        .policyKey("book_default_rate")
+                        .value(new BigDecimal("0.01")) // 0.5% 변경 예정
+                        .valueType(PointValueType.RATE)
+                        .description("도서구매 기본 적립률")
+                        .build()
         );
-        pointPolicyRepository.saveAll(policies);
+
+        for (PointPolicy policy : initPolicies) {
+            pointPolicyRepository.findById(policy.getPolicyKey())
+                    .ifPresentOrElse(
+                            existing -> {
+                                boolean needsUpdate =
+                                        existing.getValueType() != policy.getValueType() ||
+                                                !existing.getStatus().equals(policy.getStatus()) ||
+                                                existing.getValue().compareTo(policy.getValue()) != 0 ||
+                                                !existing.getDescription().equals(policy.getDescription());
+
+                                if (needsUpdate) {
+                                    existing.changeValue(policy.getValue());
+                                    existing.changeStatus(policy.getStatus());
+                                    existing.changeValueType(policy.getValueType());
+                                    existing.changeDescription(policy.getDescription());
+                                    pointPolicyRepository.save(existing);
+                                }
+                            },
+                            () -> pointPolicyRepository.save(policy)
+                    );
+        }
     }
 }

--- a/src/main/java/com/nhnacademy/illuwa/domain/point/util/PointManager.java
+++ b/src/main/java/com/nhnacademy/illuwa/domain/point/util/PointManager.java
@@ -13,6 +13,8 @@ import com.nhnacademy.illuwa.domain.pointhistory.dto.UsedPointRequest;
 import com.nhnacademy.illuwa.domain.pointhistory.entity.enums.PointReason;
 import com.nhnacademy.illuwa.domain.pointhistory.service.PointHistoryService;
 import com.nhnacademy.illuwa.domain.pointpolicy.dto.PointPolicyResponse;
+import com.nhnacademy.illuwa.domain.pointpolicy.entity.enums.PolicyStatus;
+import com.nhnacademy.illuwa.domain.pointpolicy.exception.InactivePointPolicyException;
 import com.nhnacademy.illuwa.domain.pointpolicy.exception.PointPolicyNotFoundException;
 import com.nhnacademy.illuwa.domain.pointpolicy.service.PointPolicyService;
 import lombok.RequiredArgsConstructor;
@@ -70,15 +72,18 @@ public class PointManager {
             throw new MemberNotFoundException();
         }
         PointPolicyResponse policy = pointPolicyService.findByPolicyKey(reason.getPolicyKey().orElseThrow(PointPolicyNotFoundException::new));
+        if(policy.getStatus().equals(PolicyStatus.INACTIVE)){
+            throw new InactivePointPolicyException(policy.getPolicyKey());
+        }
         BigDecimal point = calculatedFromPolicy(policy);
         updateMemberPoint(memberId, point);
         return pointHistoryService.recordPointHistory(memberId, point, reason);
     }
 
 
-    //정책 기반 포인트 계산
+    //정책 기반 포인트 계산 - 이벤트 종류는 보통 AMOUNT만 사용
     private BigDecimal calculatedFromPolicy(PointPolicyResponse policy) {
-        //AMOUNT 타입만 있지만 추후 RATE 타입은 다르게 리턴
+        //AMOUNT 타입만 있지만 추후 RATE 타입은 다르게 리턴 필요
         return policy.getValue();
     }
 

--- a/src/main/java/com/nhnacademy/illuwa/domain/pointpolicy/controller/PointPolicyController.java
+++ b/src/main/java/com/nhnacademy/illuwa/domain/pointpolicy/controller/PointPolicyController.java
@@ -25,7 +25,7 @@ public class PointPolicyController {
     }
 
     @GetMapping
-    public ResponseEntity<List<PointPolicyResponse>> getAllPointPolicies(){
+    public ResponseEntity<List<PointPolicyResponse>> getPointPolicyList(){
         return ResponseEntity.status(HttpStatus.OK).body(pointPolicyService.findAllPointPolicy());
     }
 
@@ -34,7 +34,7 @@ public class PointPolicyController {
         return ResponseEntity.status(HttpStatus.OK).body(pointPolicyService.findByPolicyKey(policyKey));
     }
 
-    @PatchMapping("/{policyKey}")
+    @PutMapping("/{policyKey}")
     public ResponseEntity<PointPolicyResponse> updatePointPolicy(@PathVariable String policyKey, @Valid @RequestBody PointPolicyUpdateRequest request){
         PointPolicyResponse response = pointPolicyService.updatePointPolicy(policyKey, request);
         return ResponseEntity.status(HttpStatus.OK).body(response);

--- a/src/main/java/com/nhnacademy/illuwa/domain/pointpolicy/dto/PointPolicyResponse.java
+++ b/src/main/java/com/nhnacademy/illuwa/domain/pointpolicy/dto/PointPolicyResponse.java
@@ -1,6 +1,7 @@
 package com.nhnacademy.illuwa.domain.pointpolicy.dto;
 
 import com.nhnacademy.illuwa.domain.pointpolicy.entity.enums.PointValueType;
+import com.nhnacademy.illuwa.domain.pointpolicy.entity.enums.PolicyStatus;
 import lombok.*;
 
 import java.math.BigDecimal;
@@ -10,6 +11,8 @@ import java.math.BigDecimal;
 @AllArgsConstructor
 public class PointPolicyResponse {
     private String policyKey;
+
+    private PolicyStatus status;
 
     private BigDecimal value;
 

--- a/src/main/java/com/nhnacademy/illuwa/domain/pointpolicy/dto/PointPolicyUpdateRequest.java
+++ b/src/main/java/com/nhnacademy/illuwa/domain/pointpolicy/dto/PointPolicyUpdateRequest.java
@@ -1,6 +1,7 @@
 package com.nhnacademy.illuwa.domain.pointpolicy.dto;
 
 import com.nhnacademy.illuwa.domain.pointpolicy.entity.enums.PointValueType;
+import com.nhnacademy.illuwa.domain.pointpolicy.entity.enums.PolicyStatus;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
@@ -9,6 +10,8 @@ import java.math.BigDecimal;
 @Data
 @Builder
 public class PointPolicyUpdateRequest {
+    private PolicyStatus status;
+
     @NotNull(message = "포인트 값은 필수입니다.")
     private BigDecimal value;
 

--- a/src/main/java/com/nhnacademy/illuwa/domain/pointpolicy/service/impl/PointPolicyServiceImpl.java
+++ b/src/main/java/com/nhnacademy/illuwa/domain/pointpolicy/service/impl/PointPolicyServiceImpl.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
+import java.math.MathContext;
 import java.util.List;
 
 @Service
@@ -64,11 +65,10 @@ public class PointPolicyServiceImpl implements PointPolicyService {
         PointPolicy pointPolicy = pointPolicyRepository.findById(policyKey)
                 .orElseThrow(() -> new PointPolicyNotFoundException(policyKey));
 
-        //타입 검증
-        validatePointPolicyValue(request.getValue(), request.getValueType());
-
         if(request.getValue() != null){
-            pointPolicy.changeValue(request.getValue());
+            validatePointPolicyValue(request.getValue(), request.getValueType());
+            BigDecimal value = request.getValue().divide(BigDecimal.valueOf(100), MathContext.DECIMAL64);
+            pointPolicy.changeValue(value);
         }
         if(request.getValueType() != null){
             pointPolicy.changeValueType(request.getValueType());
@@ -104,8 +104,8 @@ public class PointPolicyServiceImpl implements PointPolicyService {
             }
             case AMOUNT -> {
                 // 0 이상만 허용
-                if (value.compareTo(BigDecimal.ZERO) < 0) {
-                    throw new IllegalArgumentException("AMOUNT 타입은 0 이상만 허용됩니다.");
+                if (value.compareTo(BigDecimal.ZERO) <= 0) {
+                    throw new InvalidInputException("AMOUNT 타입은 0 이상만 허용됩니다.");
                 }
             }
             default -> throw new InvalidInputException("알 수 없는 valueType이에요.");


### PR DESCRIPTION
## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명
- 프론트와 연결하는 과정 중에 등록,수정,삭제 관련 로직 강화
- amount타입 값 0 안되도록 조건 변경

## 💬리뷰 요구사항(선택)
PointInitializer 초기데이터 
도서기본적립률 0.5%(bigdecimal 값으로는 0.005)로 설정하고 싶은데 코드 바꿔도 db에 반영안되는 이슈 원인을 모르겠음

## Issue Tags
> 아래 # 태그 뒤에 이슈 번호 붙여주세요!
- Closed: #167 
