### PR TITLE
Feat/247update member grade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,9 +207,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
+
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
+                    <generatedSourcesDirectory>
+                        ${project.build.directory}/generated-sources/querydsl
+                    </generatedSourcesDirectory>
                     <annotationProcessorPaths>
                         <!-- 롬복 우선순위 최상위 -->
                         <path>

--- a/src/main/java/com/nhnacademy/illuwa/common/config/AppConfig.java
+++ b/src/main/java/com/nhnacademy/illuwa/common/config/AppConfig.java
@@ -15,13 +15,14 @@ public class AppConfig {
         return new RestTemplate();
     }
 
+    /*
     @Bean
     public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory){
         RedisTemplate<String, String> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);
         return template;
 
-    }
+    }*/ // 기존 redisTemplate -> RedisConfig로 이동
 
     @Bean
     public PasswordEncoder passwordEncoder() {

--- a/src/main/java/com/nhnacademy/illuwa/common/config/RedisConfig.java
+++ b/src/main/java/com/nhnacademy/illuwa/common/config/RedisConfig.java
@@ -1,0 +1,34 @@
+package com.nhnacademy.illuwa.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> StringRedisTemplate(RedisConnectionFactory cf) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(cf);
+
+        StringRedisSerializer keySer = new StringRedisSerializer();
+        GenericJackson2JsonRedisSerializer valueSer = new GenericJackson2JsonRedisSerializer();
+
+        redisTemplate.setKeySerializer(keySer);
+        redisTemplate.setValueSerializer(valueSer);
+        redisTemplate.setHashKeySerializer(keySer);
+        redisTemplate.setHashValueSerializer(valueSer);
+        redisTemplate.afterPropertiesSet();
+        return redisTemplate;
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory cf) {
+        return new StringRedisTemplate(cf);
+    }
+}

--- a/src/main/java/com/nhnacademy/illuwa/domain/grade/service/IdemService.java
+++ b/src/main/java/com/nhnacademy/illuwa/domain/grade/service/IdemService.java
@@ -1,0 +1,33 @@
+package com.nhnacademy.illuwa.domain.grade.service;
+
+import com.sun.jdi.request.DuplicateRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+@Component
+@RequiredArgsConstructor
+public class IdemService {
+    private final RedisTemplate<String, Object> redis;
+    private static final long TTL = 60 * 60 * 24;
+
+    public <T> T run(String key, Supplier<T> action) {
+        boolean first = Boolean.TRUE.equals(redis.opsForValue().setIfAbsent(key, "LOCK", TTL, TimeUnit.SECONDS));
+
+        if(!first) {
+            // 이미 처리 -> 캐시된 응답 or 409
+            Object cached = redis.opsForValue().get(key+":resp");
+            if(cached != null) {
+                return (T) cached;
+            }
+            throw new DuplicateRequestException();
+        }
+
+        T result = action.get();
+        redis.opsForValue().set(key+":resp", result, TTL, TimeUnit.SECONDS);
+        return result;
+    }
+}

--- a/src/test/java/com/nhnacademy/illuwa/domain/member/controller/MemberGradeControllerTest.java
+++ b/src/test/java/com/nhnacademy/illuwa/domain/member/controller/MemberGradeControllerTest.java
@@ -2,12 +2,14 @@ package com.nhnacademy.illuwa.domain.member.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nhnacademy.illuwa.domain.grade.entity.enums.GradeName;
+import com.nhnacademy.illuwa.domain.grade.service.IdemService;
 import com.nhnacademy.illuwa.domain.member.dto.MemberGradeUpdateRequest;
 import com.nhnacademy.illuwa.domain.member.service.impl.MemberGradeService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
@@ -15,12 +17,14 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.function.Supplier;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(MemberGradeController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class MemberGradeControllerTest {
 
     @Autowired
@@ -28,6 +32,9 @@ class MemberGradeControllerTest {
 
     @MockBean
     private MemberGradeService memberGradeService;
+
+    @MockBean
+    private IdemService idemService;
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -42,17 +49,23 @@ class MemberGradeControllerTest {
 
         Mockito.when(memberGradeService.updateGrades(anyList())).thenReturn(2);
 
+        Mockito.when(idemService.run(Mockito.eq("test-key-1"), Mockito.any(Supplier.class)))
+                        .thenAnswer(inv -> ((Supplier<Integer>) inv.getArgument(1)).get());
+
         mockMvc.perform(post("/api/members/grades/recalculate")
+                        .header("Idempotency-Key", "test-key-1")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requests)))
                 .andExpect(status().isOk())
-                .andExpect(content().string("2"));
+                        .andExpect(content().string("2"));
+        Mockito.verify(memberGradeService, Mockito.times(1)).updateGrades(anyList());
     }
 
     @Test
     @DisplayName("등급별 포인트 지급 API 성공")
     void givePointToGrade_success() throws Exception {
         mockMvc.perform(post("/api/members/grades/{gradeName}/points", "GOLD")
+                        .header("Idempotency-Key", "test-key-1")
                         .param("point", "1500"))
                 .andExpect(status().isCreated());
 


### PR DESCRIPTION
## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명
- 멤버 등급 재조정 로직에 멱등키 추가

## 💬리뷰 요구사항(선택)

배치/운영 시나리오별 멱등성(Idempotency) 적용 효과

① 배치 재시작·수동 재트리거
	•	상황
	•	청크 1,000건씩 처리 중 70% 지점에서 오류 발생 → 재실행 필요.
	•	이미 반영된 7만 건을 또 UPDATE → DB write 2배, 등급 포인트 이중 증가/감소 위험.
	•	대응
	•	각 레코드/청크에 Idempotency-Key 부여.
	•	이미 처리된 첫 7만 건은 즉시 SKIP, 실제 끊긴 지점부터 재개.
	•	결과
	•	이중 업데이트 0건, 포인트 오류 0건.

⸻

② 운영자 “한 번 더 눌러”
	•	상황
	•	관리 콘솔에서 재계산 버튼을 연속 클릭.
	•	같은 **UPDATE … WHERE**가 N번 반복되어 DB 부하 급증.
	•	대응
	•	**두 번째 클릭부터는 캐시된 응답(HTTP 200)**만 반환.
	•	결과
	•	DB 추가 부하 없음.

⸻

③ 다중 노드 실행
	•	상황
	•	배치 노드 2대가 **동일 JobParameters**로 동시에 기동.
	•	동일 멤버를 두 노드가 동시에 처리 → 등급 변동 충돌.
	•	대응
	•	SETNX(분산 락) 사용: 동일 키에 대해 한 노드만 성공, 나머지는 건너뜀.
	•	결과
	•	동시 처리 충돌 방지, 정합성 보장.

⸻

④ 장애 후 보정 스크립트
	•	상황
	•	수동으로 “지난 3개월치 다시 계산” SQL 실행.
	•	이미 최신 상태인 컬럼까지 다시 만져 검증·롤백 번거로움.
	•	대응
	•	보정 스크립트에도 동일 Idempotency-Key 적용 → 무해한 재실행 가능.
	•	결과
	•	중복 반영 방지, 운영 리스크/롤백 비용 감소.




## Issue Tags
> 아래 # 태그 뒤에 이슈 번호 붙여주세요!
- Closed: #247 
