### PR TITLE
refactor: #250 구매확정 후 포인트 적립 비동기 처리

### DIFF
--- a/src/main/java/com/nhnacademy/illuwa/common/config/RabbitPointConfig.java
+++ b/src/main/java/com/nhnacademy/illuwa/common/config/RabbitPointConfig.java
@@ -14,8 +14,10 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class RabbitPointConfig {
     public static final String POINT_EXCHANGE = "point.exchange";
-    public static final String POINT_QUEUE = "point.used.queue";
-    public static final String POINT_ROUTING_KEY = "point.used";
+    public static final String USED_QUEUE = "point.used.queue";
+    public static final String SAVED_QUEUE = "point.saved.queue";
+    public static final String ROUTING_KEY_USED = "point.used";
+    public static final String ROUTING_KEY_SAVED = "point.saved";
 
     @Bean
     public TopicExchange pointExchange() {
@@ -24,12 +26,26 @@ public class RabbitPointConfig {
 
     @Bean
     public Queue pointUsedQueue() {
-        return new Queue(POINT_QUEUE);
+        return new Queue(USED_QUEUE);
     }
 
     @Bean
-    public Binding pointBinding() {
-        return BindingBuilder.bind(pointUsedQueue()).to(pointExchange()).with(POINT_ROUTING_KEY);
+    public Queue pointSavedQueue() {
+        return new Queue(SAVED_QUEUE);
+    }
+
+    @Bean
+    public Binding pointUsedBinding() {
+        return BindingBuilder.bind(pointUsedQueue())
+                .to(pointExchange())
+                .with(ROUTING_KEY_USED);
+    }
+
+    @Bean
+    public Binding pointSavedBinding() {
+        return BindingBuilder.bind(pointSavedQueue())
+                .to(pointExchange())
+                .with(ROUTING_KEY_SAVED);
     }
 
     @Bean(name = "pointJacksonConverter")

--- a/src/main/java/com/nhnacademy/illuwa/domain/point/consumer/PointEventConsumer.java
+++ b/src/main/java/com/nhnacademy/illuwa/domain/point/consumer/PointEventConsumer.java
@@ -1,7 +1,9 @@
 package com.nhnacademy.illuwa.domain.point.consumer;
 
 import com.nhnacademy.illuwa.common.config.RabbitPointConfig;
-import com.nhnacademy.illuwa.domain.member.dto.PointUsedEvent;
+import com.nhnacademy.illuwa.domain.point.dto.PointSavedEvent;
+import com.nhnacademy.illuwa.domain.point.dto.PointUsedEvent;
+import com.nhnacademy.illuwa.domain.point.pointhistory.dto.PointAfterOrderRequest;
 import com.nhnacademy.illuwa.domain.point.pointhistory.dto.UsedPointRequest;
 import com.nhnacademy.illuwa.domain.point.utils.PointManager;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +18,7 @@ public class PointEventConsumer {
 
     private final PointManager pointManager;
 
-    @RabbitListener(queues = RabbitPointConfig.POINT_QUEUE,
+    @RabbitListener(queues = RabbitPointConfig.USED_QUEUE,
             containerFactory = "pointListenerContainerFactory")
     public void handlePointUsedEvent(PointUsedEvent event) {
         log.info("📨 PointUsedEvent 수신 - memberId={}, usedPoint={}", event.getMemberId(), event.getUsedPoint());
@@ -27,5 +29,18 @@ public class PointEventConsumer {
                         .build();
 
         pointManager.processUsedPoint(request);
+    }
+
+    @RabbitListener(queues = RabbitPointConfig.SAVED_QUEUE,
+            containerFactory = "pointListenerContainerFactory")
+    public void handlePointSavedEvent(PointSavedEvent event) {
+        log.info("📨 PointSavedEvent 수신 - memberId={}, price={}", event.getMemberId(), event.getPrice());
+
+        PointAfterOrderRequest request = PointAfterOrderRequest.builder()
+                .memberId(event.getMemberId())
+                .price(event.getPrice())
+                .build();
+
+        pointManager.processOrderPoint(request);
     }
 }

--- a/src/main/java/com/nhnacademy/illuwa/domain/point/dto/PointSavedEvent.java
+++ b/src/main/java/com/nhnacademy/illuwa/domain/point/dto/PointSavedEvent.java
@@ -1,4 +1,4 @@
-package com.nhnacademy.illuwa.domain.member.dto;
+package com.nhnacademy.illuwa.domain.point.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -9,8 +9,8 @@ import java.math.BigDecimal;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class PointUsedEvent {
+public class PointSavedEvent {
     private Long memberId;
-    private BigDecimal usedPoint;
+    private BigDecimal price;
 }
 

--- a/src/main/java/com/nhnacademy/illuwa/domain/point/dto/PointUsedEvent.java
+++ b/src/main/java/com/nhnacademy/illuwa/domain/point/dto/PointUsedEvent.java
@@ -1,0 +1,16 @@
+package com.nhnacademy.illuwa.domain.point.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PointUsedEvent {
+    private Long memberId;
+    private BigDecimal usedPoint;
+}
+

--- a/src/main/java/com/nhnacademy/illuwa/domain/point/pointhistory/controller/PointHistoryController.java
+++ b/src/main/java/com/nhnacademy/illuwa/domain/point/pointhistory/controller/PointHistoryController.java
@@ -69,14 +69,14 @@ public class PointHistoryController {
                 .orElse(ResponseEntity.noContent().build());
     }
 
-    @Operation(summary = "주문 포인트 적립", description = "주문 완료 후 적립 포인트를 등록합니다.")
+/*    @Operation(summary = "주문 포인트 적립", description = "주문 완료 후 적립 포인트를 등록합니다.")
     @ApiResponse(responseCode = "201", description = "주문 포인트 적립 성공")
     @PostMapping("/order/earn")
     public ResponseEntity<PointHistoryResponse> earnPointAfterOrder(@RequestBody PointAfterOrderRequest request) {
         return pointManager.processOrderPoint(request)
                 .map(response -> ResponseEntity.status(HttpStatus.CREATED).body(response))
                 .orElse(ResponseEntity.noContent().build());
-    }
+    }*/
 
     @Operation(summary = "주문 시 포인트 사용", description = "주문 시 사용한 포인트를 차감합니다.")
     @ApiResponse(responseCode = "201", description = "포인트 사용 처리 완료")

--- a/src/test/java/com/nhnacademy/illuwa/domain/point/pointhistory/controller/PointHistoryControllerTest.java
+++ b/src/test/java/com/nhnacademy/illuwa/domain/point/pointhistory/controller/PointHistoryControllerTest.java
@@ -8,6 +8,7 @@ import com.nhnacademy.illuwa.domain.point.pointhistory.entity.enums.PointHistory
 import com.nhnacademy.illuwa.domain.point.pointhistory.entity.enums.PointReason;
 import com.nhnacademy.illuwa.domain.point.utils.PointManager;
 import com.nhnacademy.illuwa.domain.point.pointhistory.service.PointHistoryService;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -114,6 +115,7 @@ class PointHistoryControllerTest {
                 .andExpect(jsonPath("$.createdAt").exists());
     }
 
+    @Disabled
     @Test
     @DisplayName("주문 후 포인트 적립")
     void testEarnPointAfterOrder() throws Exception {


### PR DESCRIPTION
## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명
- 포인트 차감을 비동기 처리로 전환하신 것을 보고
- 구매확정건에 대한 포인트 적립도 비동기 처리로 변경

## 💬리뷰 요구사항(선택)
구매 후 포인트 적립 api 메서드 제거 예정
RabbitConfig 내 상수명 변경 이뤄짐

## Issue Tags
> 아래 # 태그 뒤에 이슈 번호 붙여주세요!
- Closed: #250 
